### PR TITLE
Use joda-time 2.8.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-maven-s3-wagon "0.2.6-SNAPSHOT"
+(defproject lein-maven-s3-wagon "0.2.5-SNAPSHOT"
   :description "A leiningen plugin for publishing to a private S3
   maven repository."
   :url "http://github.com/pjstadig/lein-maven-s3-wagon/"

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject lein-maven-s3-wagon "0.2.5-SNAPSHOT"
+(defproject lein-maven-s3-wagon "0.2.6-SNAPSHOT"
   :description "A leiningen plugin for publishing to a private S3
   maven repository."
   :url "http://github.com/pjstadig/lein-maven-s3-wagon/"
   :license {:name "Mozilla Public License, v. 2.0"
             :url "http://mozilla.org/MPL/2.0/"}
-  :dependencies [[joda-time "2.2"]
+  :dependencies [[joda-time "2.8.1"]
                  [pjstadig/maven-s3-wagon "1.3.4" :exclusions [joda-time]]]
   :repositories [["releases" {:url "https://clojars.org/repo/"
                               :creds :gpg}]]


### PR DESCRIPTION
This updates joda-time to version 2.8.1. This is due to a bug in older versions of
joda-time which cause it to [break when used with the AWS SDK](https://github.com/aws/aws-sdk-java/issues/484).

This bumps the version to `0.2.6-SNAPSHOT`. I'm unsure on the version strategy, just let me know
if this is not the version number you'd like.
